### PR TITLE
fix: err var assignment

### DIFF
--- a/abci/checktx/mev_check_tx.go
+++ b/abci/checktx/mev_check_tx.go
@@ -102,9 +102,8 @@ func (handler *MEVCheckTxHandler) CheckTx() CheckTx {
 					"err", rec,
 				)
 
-				err = fmt.Errorf("panic in check tx handler: %s", rec)
 				resp = sdkerrors.ResponseCheckTxWithEvents(
-					err,
+					fmt.Errorf("panic in check tx handler: %s", rec),
 					0,
 					0,
 					nil,


### PR DESCRIPTION
Fixes an issue with an `err` variable assignment throwing an unnecessary error in `CheckTx` causing nodes to panic.