### PR TITLE
fix: check contains by key instead of object equality

### DIFF
--- a/block/base/default.go
+++ b/block/base/default.go
@@ -121,12 +121,8 @@ func (mp *DefaultMempool[C]) Contains(tx sdk.Tx) bool {
 	}
 
 	// Check if we have this sender:nonce combination
-	if element, exists := mp.seen[key]; exists {
-		// Return true only if it's the exact same transaction object
-		return element.Value.(sdk.Tx) == tx
-	}
-
-	return false
+	_, exists := mp.seen[key]
+	return exists
 }
 
 // DefaultIterator implements sdkmempool.Iterator for FIFO mempool

--- a/block/base/default_test.go
+++ b/block/base/default_test.go
@@ -12,6 +12,7 @@ import (
 
 	signer_extraction "github.com/skip-mev/block-sdk/v2/adapters/signer_extraction_adapter"
 	"github.com/skip-mev/block-sdk/v2/block/base"
+	"github.com/skip-mev/block-sdk/v2/block/utils"
 	"github.com/skip-mev/block-sdk/v2/testutils"
 )
 
@@ -247,6 +248,36 @@ func TestDefaultMempool_Integration(t *testing.T) {
 		require.Equal(t, txs[1], collectedTxs[1])
 		require.Equal(t, txs[2], collectedTxs[2])
 	})
+}
+
+// TestDefaultMempool_ContainsWithRedecodedTransactions tests that Contains() works correctly
+// with transactions that have been re-decoded (different object, same content)
+func TestDefaultMempool_ContainsWithRedecodedTransactions(t *testing.T) {
+	ctx := context.Background()
+	accounts := testutils.RandomAccounts(rand.New(rand.NewSource(1)), 1)
+	txConfig := testutils.CreateTestEncodingConfig().TxConfig
+	signerExtractor := signer_extraction.NewDefaultAdapter()
+	mp := base.NewDefaultMempool[int64](5, signerExtractor)
+
+	// Create and insert original transaction
+	originalTx, err := testutils.CreateTx(txConfig, accounts[0], 0, 0, nil, sdk.NewCoin("stake", math.NewInt(100)))
+	require.NoError(t, err)
+	err = mp.Insert(ctx, originalTx)
+	require.NoError(t, err)
+
+	// Encode and decode to create a new object with same content
+	encodedTxs, err := utils.GetEncodedTxs(txConfig.TxEncoder(), []sdk.Tx{originalTx})
+	require.NoError(t, err)
+	decodedTxs, err := utils.GetDecodedTxs(txConfig.TxDecoder(), encodedTxs)
+	require.NoError(t, err)
+	redecodedTx := decodedTxs[0]
+
+	// Verify they are different objects but same content
+	require.False(t, originalTx == redecodedTx, "Should be different objects")
+
+	// Contains() should return true for both original and re-decoded transaction
+	require.True(t, mp.Contains(originalTx), "Should contain original transaction")
+	require.True(t, mp.Contains(redecodedTx), "Should contain re-decoded transaction")
 }
 
 // TestDefaultMempool_ImplementsInterface verifies that DefaultMempool implements MempoolInterface


### PR DESCRIPTION
Attempt to fix `failed to insert tx into mempool: pool reached max tx capacity` in #3 failed as the potential actual root cause lies in object equality checking. This PR uses `sender:nonce` key to check equality in `Contains` instead of using object equality.

Object equality checking is flawed because along the transaction lifecycle, it gets encoded to bytes and decoded to object again along the process, that makes object equality checking fails because it's not the same object anymore.

`LanedMempool` which acts as a controller for each lane mempool [checks if the lane contains a tx before removal](https://github.com/osmosis-labs/block-sdk/blob/3684c82f9673c3210ca89c1a3b4511b62cafe637/block/mempool.go#L115-L132), so with `Contains` implementation bug preventing it from finding the tx to remove, `DefaultMempool` keeps all the tx that has ever inserted until it reaches max capacity.

[The original `DefaultMempool`](https://github.com/osmosis-labs/block-sdk/blob/3684c82f9673c3210ca89c1a3b4511b62cafe637/block/base/default.go#L68-L76) that has this issue also relies on object equality to check if mempool contains a transaction.

[`PriorityNonceMempool`](https://github.com/osmosis-labs/block-sdk/blob/3684c82f9673c3210ca89c1a3b4511b62cafe637/block/base/priority_nonce.go#L473-L489) which was the previous default doesn't have this issue as it relies on existence if matching sender and nonce. 